### PR TITLE
[Fix #12] Solve name collisions in DataLoader and SetLoader classes

### DIFF
--- a/loader.lua
+++ b/loader.lua
@@ -539,7 +539,7 @@ function SetLoader:__init(...)
 
     self.hdf5_group = args.hdf5_group
     self.set = self:_get_set_name()
-    self._object_fields = self:_get_object_fields_data()
+    self.object_fields = self:_get_object_fields_data()
     self.nelems = self:_get_num_elements()
     self._fields = self:_get_field_names()
     self.fields = self:_load_hdf5_fields()  -- add all hdf5 datasets as data fields
@@ -587,7 +587,7 @@ end
 function SetLoader:_load_hdf5_fields()
     local fields = {}
     for _, field in pairs(self._fields) do
-        local obj_id = get_value_id_in_list(field, self._object_fields)
+        local obj_id = get_value_id_in_list(field, self.object_fields)
         local hdf5_dataset = self:_get_hdf5_dataset(field)
         fields[field] = dbcollection.FieldLoader(hdf5_dataset, obj_id)
     end
@@ -770,7 +770,7 @@ end
 
 function SetLoader:_get_object_field_data_from_idx(idx)
     local data = {}
-    for k, field in ipairs(self._object_fields) do
+    for k, field in ipairs(self.object_fields) do
         if idx[k] >= 0 then
             -- because python is 0-indexed, we need to increment
             -- the hdf5 data elements by one to get the correct index
@@ -808,7 +808,7 @@ function SetLoader:size(...)
     local args = initcheck(...)
 
     if args.field ~= 'object_ids' then
-        local is_field_valid = is_val_in_table(args.field, self._object_fields)
+        local is_field_valid = is_val_in_table(args.field, self.object_fields)
         assert(is_field_valid, ('Field \'%s\' does not exist in the \'%s\' set.'):format(field, self.set))
     end
 
@@ -866,7 +866,7 @@ end
 
 function SetLoader:_validate_object_field_id_input(field)
     assert(field, 'Must input a valid field.')
-    assert(is_val_in_table(field, self._object_fields),
+    assert(is_val_in_table(field, self.object_fields),
            ('Field \'%s\' does not exist \'object_fields\' set.')
            :format(field, self.set))
 end
@@ -978,7 +978,7 @@ function SetLoader:_set_field_metadata(field, shape, dtype)
     assert(shape)
     assert(dtype)
     local s_obj = ''
-    if is_val_in_table(field, self._object_fields) then
+    if is_val_in_table(field, self.object_fields) then
         s_obj = ("(in 'object_ids', position = %d)"):format(self:object_field_id(field))
     end
     table.insert(self._fields_info, {

--- a/loader.lua
+++ b/loader.lua
@@ -114,9 +114,9 @@ function DataLoader:__init(...)
                 hdf5 file object handler.
             root_path : str
                 Default data group of the hdf5 file.
-            sets : tuple
+            sets : table
                 List of names of set splits (e.g. train, test, val, etc.)
-            object_fields : dict
+            object_fields : table
                 Data field names for each set split.
 
         ]],
@@ -142,7 +142,7 @@ function DataLoader:__init(...)
     self.file = self:_open_hdf5_file()
     self.root_path = '/'
 
-    self.sets = self:_get_set_names()
+    self._sets = self:_get_set_names()
     self.object_fields = self:_get_object_fields()
 
     -- make links for all groups (train/val/test/etc) for easier access
@@ -164,7 +164,7 @@ end
 
 function DataLoader:_get_object_fields()
     local object_fields = {}
-    for _, set in pairs(self.sets) do
+    for _, set in pairs(self._sets) do
         object_fields[set] = self:_get_object_fields_data_from_set(set)
     end
     return object_fields
@@ -180,7 +180,7 @@ function DataLoader:_get_object_fields_data_from_set(set)
 end
 
 function DataLoader:_set_SetLoaders()
-    for _, set in pairs(self.sets) do
+    for _, set in pairs(self._sets) do
         local hdf5_group_path = self.root_path .. set
         self[set] = dbcollection.SetLoader(self:_get_hdf5_group(hdf5_group_path))
     end
@@ -248,7 +248,7 @@ function DataLoader:get(...)
 end
 
 function DataLoader:_check_if_set_is_valid(set)
-    local is_set_name_valid = is_val_in_table(set, self.sets)
+    local is_set_name_valid = is_val_in_table(set, self._sets)
     assert(is_set_name_valid, ('Set %s does not exist for this dataset.'):format(set))
 end
 
@@ -362,7 +362,7 @@ end
 function DataLoader:_get_set_size_all(field)
     assert(field, 'Must input a field')
     local out = {}
-    for _, set_name in pairs(self.sets) do
+    for _, set_name in pairs(self._sets) do
         out[set_name] = self:_get_set_size(set_name, field)
     end
     return out
@@ -405,7 +405,7 @@ end
 
 function DataLoader:_get_set_list_all()
     local out = {}
-    for _, set_name in pairs(self.sets) do
+    for _, set_name in pairs(self._sets) do
         out[set_name] = self[set_name]:list()
     end
     return out
@@ -487,13 +487,13 @@ function DataLoader:_get_set_info(set)
 end
 
 function DataLoader:_get_set_info_all()
-    for _, set_name in pairs(self.sets) do
+    for _, set_name in pairs(self._sets) do
         self[set_name]:info()
     end
 end
 
 function DataLoader:__len__()
-    return #self.sets
+    return #self._sets
 end
 
 function DataLoader:__tostring__()

--- a/loader.lua
+++ b/loader.lua
@@ -542,7 +542,7 @@ function SetLoader:__init(...)
     self._object_fields = self:_get_object_fields_data()
     self.nelems = self:_get_num_elements()
     self._fields = self:_get_field_names()
-    self:_load_hdf5_fields()  -- add all hdf5 datasets as data fields
+    self.fields = self:_load_hdf5_fields()  -- add all hdf5 datasets as data fields
 end
 
 function SetLoader:_get_set_name()
@@ -585,11 +585,13 @@ function SetLoader:_get_num_elements()
 end
 
 function SetLoader:_load_hdf5_fields()
+    local fields = {}
     for _, field in pairs(self._fields) do
         local obj_id = get_value_id_in_list(field, self._object_fields)
         local hdf5_dataset = self:_get_hdf5_dataset(field)
-        self[field] = dbcollection.FieldLoader(hdf5_dataset, obj_id)
+        fields[field] = dbcollection.FieldLoader(hdf5_dataset, obj_id)
     end
+    return fields
 end
 
 function SetLoader:get(...)
@@ -642,7 +644,7 @@ function SetLoader:get(...)
 
     local is_field_valid = is_val_in_table(args.field, self._fields)
     assert(is_field_valid, ('Field \'%s\' does not exist in the \'%s\' set.'):format(args.field, self.set))
-    return self[args.field]:get(args.index)
+    return self.fields[args.field]:get(args.index)
 end
 
 function SetLoader:object(...)
@@ -810,7 +812,7 @@ function SetLoader:size(...)
         assert(is_field_valid, ('Field \'%s\' does not exist in the \'%s\' set.'):format(field, self.set))
     end
 
-    return self[args.field]:size()
+    return self.fields[args.field]:size()
 end
 
 function SetLoader:list(...)
@@ -857,7 +859,7 @@ function SetLoader:object_field_id(...)
     local args = initcheck(...)
 
     self:_validate_object_field_id_input(args.field)
-    local idx = self[args.field]:object_field_id()
+    local idx = self.fields[args.field]:object_field_id()
     assert(idx, ('Field \'%s\' does not exist in \'_object_fields\''):format(args.field))
     return idx
 end

--- a/loader.lua
+++ b/loader.lua
@@ -524,11 +524,13 @@ function SetLoader:__init(...)
                 hdf5 group object handler.
             set : str
                 Name of the set.
-            fields : tuple
+            fields : table
+                List of all field loaders of the set.
+            _fields : table
                 List of all field names of the set.
-            _object_fields : tuple
+            object_fields : table
                 List of all field names of the set contained by the 'object_ids' list.
-            nelems : int
+            nelems : number
                 Number of rows in 'object_ids'.
         ]],
         {name="hdf5_group", type="hdf5.HDF5Group",
@@ -823,8 +825,8 @@ function SetLoader:list(...)
 
             Returns
             -------
-            list
-                List of all data fields of the dataset.
+            table
+                List of all data field names of the dataset.
         ]]
     }
 
@@ -1116,13 +1118,13 @@ function FieldLoader:__init(...)
                 Name of the set.
             name : str
                 Name of the field.
-            type : type
+            type : str
                 Type of the field's data.
-            shape : tuple
+            shape : table
                 Shape of the field's data.
-            fillvalue : int
+            fillvalue : number
                 Value used to pad arrays when storing the data in the hdf5 file.
-            obj_id : int
+            obj_id : number
                 Identifier of the field if contained in the 'object_ids' list.
         ]],
         {name="hdf5_field", type="hdf5.HDF5DataSet",

--- a/loader.lua
+++ b/loader.lua
@@ -539,9 +539,9 @@ function SetLoader:__init(...)
 
     self.hdf5_group = args.hdf5_group
     self.set = self:_get_set_name()
-    self.fields = self:_get_fields()
     self._object_fields = self:_get_object_fields_data()
     self.nelems = self:_get_num_elements()
+    self._fields = self:_get_field_names()
     self:_load_hdf5_fields()  -- add all hdf5 datasets as data fields
 end
 
@@ -551,7 +551,7 @@ function SetLoader:_get_set_name()
     return str[1]
 end
 
-function SetLoader:_get_fields()
+function SetLoader:_get_field_names()
     local fields = {}
     for k, v in pairs(self.hdf5_group._children) do
         table.insert(fields, k)
@@ -585,7 +585,7 @@ function SetLoader:_get_num_elements()
 end
 
 function SetLoader:_load_hdf5_fields()
-    for _, field in pairs(self.fields) do
+    for _, field in pairs(self._fields) do
         local obj_id = get_value_id_in_list(field, self._object_fields)
         local hdf5_dataset = self:_get_hdf5_dataset(field)
         self[field] = dbcollection.FieldLoader(hdf5_dataset, obj_id)
@@ -640,7 +640,7 @@ function SetLoader:get(...)
         args = initcheck(...)
     end
 
-    local is_field_valid = is_val_in_table(args.field, self.fields)
+    local is_field_valid = is_val_in_table(args.field, self._fields)
     assert(is_field_valid, ('Field \'%s\' does not exist in the \'%s\' set.'):format(args.field, self.set))
     return self[args.field]:get(args.index)
 end
@@ -828,7 +828,7 @@ function SetLoader:list(...)
 
     local args = initcheck(...)
 
-    return self.fields
+    return self._fields
 end
 
 function SetLoader:object_field_id(...)
@@ -918,8 +918,8 @@ function SetLoader:_init_max_sizes()
 end
 
 function SetLoader:_set_info_data()
-    for i=1, #self.fields do
-        self:_set_field_data(self.fields[i])
+    for i=1, #self._fields do
+        self:_set_field_data(self._fields[i])
     end
 end
 

--- a/tests/test_loader.lua
+++ b/tests/test_loader.lua
@@ -639,7 +639,7 @@ function test.test_DataLoader_init()
     tester:eq(DataLoader.task, task)
     tester:eq(DataLoader.data_dir, data_dir)
     tester:eq(DataLoader.hdf5_filepath, file)
-    tester:eq(DataLoader.sets, {'test','train'})
+    tester:eq(DataLoader._sets, {'test','train'})
 end
 
 function test.test_DataLoader_get_single_obj()

--- a/tests/test_loader.lua
+++ b/tests/test_loader.lua
@@ -403,7 +403,7 @@ end
 function test.test_SetLoader_get_data_single_obj_in_memory()
     local set_loader, set_data = load_test_data_SetLoader('train')
 
-    set_loader.data:to_memory(true)
+    set_loader.fields.data:to_memory(true)
     local id = 1
     local data = set_loader:get('data', id)
 
@@ -422,7 +422,7 @@ end
 function test.test_SetLoader_get_data_two_objs_in_memory()
     local set_loader, set_data = load_test_data_SetLoader('train')
 
-    set_loader.data:to_memory(true)
+    set_loader.fields.data:to_memory(true)
     local id = {1,1}
     local data = set_loader:get('data', id)
 
@@ -441,7 +441,7 @@ end
 function test.test_SetLoader_get_data_multiple_objs_in_memory()
     local set_loader, set_data = load_test_data_SetLoader('train')
 
-    set_loader.data:to_memory(true)
+    set_loader.fields.data:to_memory(true)
     local id = {1,3}
     local data = set_loader:get('data', id)
 
@@ -459,7 +459,7 @@ end
 function test.test_SetLoader_get_data_all_obj_in_memory()
     local set_loader, set_data = load_test_data_SetLoader('train')
 
-    set_loader.data:to_memory(true)
+    set_loader.fields.data:to_memory(true)
     local data = set_loader:get('data')
 
     tester:eq(data, set_data['data'])
@@ -477,7 +477,7 @@ end
 function test.test_SetLoader_get_data_single_obj_object_ids_in_memory()
     local set_loader, set_data = load_test_data_SetLoader('train')
 
-    set_loader.data:to_memory(true)
+    set_loader.fields.data:to_memory(true)
     local id = 1
     local data = set_loader:get('object_ids', id)
 

--- a/tests/test_loader.lua
+++ b/tests/test_loader.lua
@@ -668,6 +668,17 @@ function test.test_DataLoader_get_single_obj_named_args()
     tester:eq(data, dataset[set][field][id])
 end
 
+function test.test_DataLoader_get_single_obj_access_via_SetLoader()
+    local data_loader, dataset = load_test_data_DataLoader()
+
+    local set = 'train'
+    local id = 1
+    local field = 'data'
+    local data = data_loader.sets[set]:get(field, id)
+
+    tester:eq(data, dataset[set][field][id])
+end
+
 function test.test_DataLoader_get_two_objs()
     local data_loader, dataset = load_test_data_DataLoader()
 

--- a/tests/test_loader.lua
+++ b/tests/test_loader.lua
@@ -387,7 +387,7 @@ function test.test_SetLoader__init()
 
     tester:assert(setLoader ~= nil)
     tester:eq(setLoader.set, set)
-    tester:eq(setLoader._object_fields, ascii_to_str(dataset[set]['object_fields']))
+    tester:eq(setLoader.object_fields, ascii_to_str(dataset[set]['object_fields']))
     tester:eq(setLoader.nelems, 5)
 end
 


### PR DESCRIPTION
This PR fixes #12 by using subtables to store `SetLoader` and `FieldLoader` objects thus avoiding name collisions with other attributes.